### PR TITLE
Implmenting /addCredits and /transferCredits endpoints

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -27,7 +27,7 @@
     <div class=metanav>
 
       {% if "username" in session %}
-        Hello, {{ session["firstName"] }}! Balance: ${{ session["balance"] }} <a href="{{ url_for('logout') }}">logout</a>
+        Hello, {{ session["firstName"] }}! Balance: ${{ get_balance(session["username"]) }} <a href="{{ url_for('logout') }}">logout</a>
 
       {% else %}
         <a href="{{ url_for('login') }}">login</a>


### PR DESCRIPTION
I took some creative liberties and made the following decisions:
- If the user tries to transfer money to a nonexistent user, rather than fail, which will provide a boolean indicator that attackers can use to brute force usernames, the app will just withdraw credits from the user and they will effectively vanish.
- Users cannot transfer credits they don't have (and thus have a negative account balance)

Q: Should we be limiting the amount of credits the user can deposit?